### PR TITLE
Catch all Java exceptions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,8 +31,8 @@
 [submodule "spec"]
 	path = spec
 	url = https://github.com/package-url/purl-spec
-[submodule "survey/drivers/sonatype/package-url-java/repo"]
-	path = survey/drivers/sonatype/package-url-java/repo
+[submodule "survey/drivers/sonatype/package_url_java/repo"]
+	path = survey/drivers/sonatype/package_url_java/repo
 	url = https://github.com/sonatype/package-url-java.git
 [submodule "survey/drivers/maennchen/purl/repo"]
 	path = survey/drivers/maennchen/purl/repo

--- a/survey/drivers/package_url/packageurl_java/src/main/java/format.java
+++ b/survey/drivers/package_url/packageurl_java/src/main/java/format.java
@@ -3,7 +3,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.TreeMap;
 
-import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DatabindException;
@@ -31,12 +30,7 @@ public class format {
                 }
                 PackageURL purl = new PackageURL(parts.type, parts.namespace, parts.name, parts.version, qualifiers, parts.subpath);
                 System.out.println(purl);
-            } catch (MalformedPackageURLException e) {
-                Error error = new Error();
-                error.error = e.toString();
-                mapper.writeValue(System.out, error);
-                System.out.println();
-            } catch (NullPointerException e) {
+            } catch (Exception e) {
                 Error error = new Error();
                 error.error = e.toString();
                 mapper.writeValue(System.out, error);

--- a/survey/drivers/package_url/packageurl_java/src/main/java/parse.java
+++ b/survey/drivers/package_url/packageurl_java/src/main/java/parse.java
@@ -2,7 +2,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,11 +30,7 @@ public class parse {
                 parts.qualifiers = purl.getQualifiers();
                 parts.subpath = purl.getSubpath();
                 mapper.writeValue(System.out, parts);
-            } catch (MalformedPackageURLException e) {
-                Error error = new Error();
-                error.error = e.toString();
-                mapper.writeValue(System.out, error);
-            } catch (NullPointerException e) {
+            } catch (Exception e) {
                 Error error = new Error();
                 error.error = e.toString();
                 mapper.writeValue(System.out, error);

--- a/survey/drivers/sonatype/package_url_java/src/main/java/format.java
+++ b/survey/drivers/sonatype/package_url_java/src/main/java/format.java
@@ -3,7 +3,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.TreeMap;
 
-import org.sonatype.goodies.packageurl.InvalidException;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DatabindException;
@@ -31,7 +30,7 @@ public class format {
                 }
                 PackageUrl purl = PackageUrl.builder().type(parts.type).namespace(parts.namespace).name(parts.name).version(parts.version).qualifiers(qualifiers).subpath(parts.subpath).build();
                 System.out.println(purl);
-            } catch (InvalidException e) {
+            } catch (Exception e) {
                 Error error = new Error();
                 error.error = e.toString();
                 mapper.writeValue(System.out, error);

--- a/survey/drivers/sonatype/package_url_java/src/main/java/parse.java
+++ b/survey/drivers/sonatype/package_url_java/src/main/java/parse.java
@@ -2,7 +2,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import org.sonatype.goodies.packageurl.InvalidException;
 import org.sonatype.goodies.packageurl.PackageUrl;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,7 +30,7 @@ public class parse {
                 parts.qualifiers = purl.getQualifiers();
                 parts.subpath = purl.getSubpathAsString();
                 mapper.writeValue(System.out, parts);
-            } catch (InvalidException e) {
+            } catch (Exception e) {
                 Error error = new Error();
                 error.error = e.toString();
                 mapper.writeValue(System.out, error);


### PR DESCRIPTION
Originally, I intended to only catch the documented exceptions, but I've found bugs in both Java implementations that cause them to throw undocumented exceptions, so we'll just catch them all.